### PR TITLE
chore: enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: node_js
+node_js: '0.12'
+before_script:
+- npm install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Galvatron
+# [![Build Status](https://travis-ci.org/treshugart/galvatron.svg?branch=master)](https://travis-ci.org/treshugart/galvatron) Galvatron
 
 A library of streaming helpers for tracing, watching and transforming JavaScript files.
 


### PR DESCRIPTION
This adds a .travis.yml file to enable travis builds. After merging this, the project has to be enabled in Travis CI.
